### PR TITLE
Customized vendor-dir

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -64,7 +64,8 @@ cp $BP_DIR/support/boot.sh .
 
 if [[ -f $PROJECT_ROOT/composer.json ]]; then
     # Caching: pre-install
-    CACHED_DIRS="vendor"
+    CACHED_DIRS=$(cat $PROJECT_ROOT/composer.json | jq -e -r '.config["vendor-dir"]') || CACHED_DIRS="vendor"
+
     mkdir -p $CACHE_DIR
     for dir in $CACHED_DIRS; do
         if [[ -e $PROJECT_ROOT/$dir ]]; then


### PR DESCRIPTION
Parse the composer.json and set the "vendor-dir" as CACHED_DIR
if the user customized the "vendor-dir".
