### PR TITLE
Export CACHE_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,6 +37,8 @@ BP_DIR=$(readlink -f $(dirname $BIN_DIR))
 BUILD_DIR=$1
 CACHE_DIR=$2
 
+export CACHE_DIR
+
 APACHE_PATH="$BUILD_DIR/apache"
 PHP_PATH="$BUILD_DIR/php"
 


### PR DESCRIPTION
To enable custom scripts to make use of the CACHE_DIR this needs to be
exported to make it available for composer scripts.
