### PR TITLE
Fix for the vendor-dir handling

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,7 +89,7 @@ if [[ -f $PROJECT_ROOT/composer.json ]]; then
 
     # Caching: post-install
     for dir in $CACHED_DIRS; do
-        rm -rf $CACHE_DIR/$dir
+        rm -rf $CACHE_DIR/${dir##*/}
         cp -R $PROJECT_ROOT/$dir $CACHE_DIR/
     done
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -73,7 +73,9 @@ if [[ -f $PROJECT_ROOT/composer.json ]]; then
         if [[ -e $PROJECT_ROOT/$dir ]]; then
             cp -R $PROJECT_ROOT/$dir $CACHE_DIR/ &> /dev/null || true
         fi
-        cp -R $CACHE_DIR/$dir $PROJECT_ROOT/ &> /dev/null || true
+        
+        mkdir -p $PROJECT_ROOT/$dir
+        cp -R $CACHE_DIR/${dir##*/}/* $PROJECT_ROOT/$dir/ &> /dev/null || true
     done
 
     # Install composer


### PR DESCRIPTION
Otherwise it fails if vendor-dir is not in the root.

So, if "vendor-dir: somesome/vendor", cp command will only create "vendor" folder in the $CACHE_DIR, but rm will try to delete "someplace/vendor".