### PR TITLE
Add --ignore-platform-reqs to composer install

### DIFF
--- a/bin/util/blackfire.sh
+++ b/bin/util/blackfire.sh
@@ -56,4 +56,7 @@ else
   echo "Blackfire credentials unavailable - extension disabled"
 fi
 EOF
+
+  # We have to ignore the platform requirements otherwise composer will fail
+  COMPOSER_INSTALL_ARGS="$COMPOSER_INSTALL_ARGS --ignore-platform-reqs"
 }


### PR DESCRIPTION
We use the composer.json to define the extensions to install (for now Blackfire), then we install them and finally we run `composer install`

But because we are playing with two different environments `composer install` will fail: we install the extensions in the application environment (the one we are building) but we run `composer install` in the "build" environment which doesn't contain the blackfire extension. One workaround is to tell composer to not check the php extensions (`--ignore-platform-reqs`).